### PR TITLE
Pakwijn toegevoegd aan navbar.

### DIFF
--- a/src/includes/navbar.pug
+++ b/src/includes/navbar.pug
@@ -17,6 +17,8 @@ nav.navbar.navbar-expand-lg.navbar-dark.red-bg.sticky-top
                         | Stukken
                     ul.dropdown-menu.dropdown-menu-end(aria-labelledby='navbarDropdownBlog')
                         li
+                            a.dropdown-item(href='./stukken.pug#pakwijn') Pakwijn
+                        li
                             a.dropdown-item(href='./stukken.pug#servetetiquette') De Servetetiquette
                         li
                             a.dropdown-item(href='./stukken.pug#wijn') Wijn in de mythologie en de oudheid


### PR DESCRIPTION
Reden: als je op de stukken klikt, dan verwacht de pagina dat je een keuze maakt tussen alle stukken, maar als je naar Pakwijn wilt dan kan dat niet.