### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
               patterns:
                   - "parcel"
                   - "@parcel/*"
+    - package-ecosystem: "github-actions"
+      directory: /
+      schedule:
+          interval: "weekly"
+      groups:
+          github-actions:
+              patterns:
+                  - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,20 @@
+name: Dependabot Auto Approve and Merge
+
+on:
+    pull_request:
+        branches: [ "master" ]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    dependabot:
+        uses: GEWIS/actions/.github/workflows/dependabot-auto-merge.yml@v1
+        permissions:
+            contents: write
+            pull-requests: write
+        with:
+            auto-approve: true
+            auto-merge: true
+            merge-method: 'squash'


### PR DESCRIPTION
Adds a Dependabot auto-merge workflow that calls the reusable `dependabot-auto-merge.yml@v1` from GEWIS/actions, the same way this repo already uses the yarn lint-and-build workflow. For dependabot PRs into `master`, it auto-approves and turns on GitHub auto-merge (squash) so dependency bumps land once CI passes, without waiting on a manual review.

Also adds a `github-actions` ecosystem to `dependabot.yml` (weekly, grouped) so the action pins stay current alongside the existing npm updates.